### PR TITLE
Fix issue #49: Show correct time on login/lock screen

### DIFF
--- a/backend/functions-localize.sh
+++ b/backend/functions-localize.sh
@@ -212,6 +212,7 @@ set_timezone()
 {
   TZONE="$1"
   cp ${FSMNT}/usr/share/zoneinfo/${TZONE} ${FSMNT}/etc/localtime
+  echo ${TZONE} | tee ${FSMNT}/var/db/zoneinfo > /dev/null
 };
 
 # Function which enables / disables NTP


### PR DESCRIPTION
During install, the file /var/db/zoneinfo is not created. This change now creates the file so the user's local time is shown on the login and lock screens.

## Summary by Sourcery

Bug Fixes:
- Save the selected timezone to `/var/db/zoneinfo` during setup.