### PR TITLE
Fix Users path for Gershwin

### DIFF
--- a/backend/functions-users.sh
+++ b/backend/functions-users.sh
@@ -85,7 +85,7 @@ add_user()
 
 remove_live_user()
 {
-  if [ -d "/usr/home/ghostbsd" ] || [ -d "/home/ghostbsd" ] || [ -d "/Users/ghostbsd" ]
+  if [ -d "/usr/home/ghostbsd" ] || [ -d "/home/ghostbsd" ] || [ -d "/Local/Users/ghostbsd" ]
   then
     echo "Remove GhostBSD live user"
     run_chroot_cmd "pw userdel -n ghostbsd -r"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix detection of the GhostBSD live user by checking the updated /Local/Users/ghostbsd home directory path instead of the old /Users/ghostbsd path.