### PR TITLE
Fix and improve GELI disk encryption support

### DIFF
--- a/backend/functions-cleanup.sh
+++ b/backend/functions-cleanup.sh
@@ -223,7 +223,15 @@ setup_fstab()
       # Echo out the fstab entry now
       if [ "${PARTFS}" = "SWAP" ]
       then
-        echo "/dev/${DEVICE}	none		swap	${MNTOPTS}	0	0" >> ${FSTAB}
+        # For encrypted swap, use the raw device with .eli suffix so the
+        # kernel creates a one-time geli provider with a random key at boot.
+        # The key is discarded on reboot, which is the standard FreeBSD
+        # approach (same as bsdinstall).
+        if [ "${PARTENC}" = "ON" ] ; then
+          echo "/dev/${PARTDEV}.eli	none		swap	${MNTOPTS}	0	0" >> ${FSTAB}
+        else
+          echo "/dev/${DEVICE}	none		swap	${MNTOPTS}	0	0" >> ${FSTAB}
+        fi
       else
         echo "/dev/${DEVICE}	${PARTMNT}		ufs	${MNTOPTS}	1	1" >> ${FSTAB}
       fi
@@ -265,7 +273,10 @@ setup_gmirror()
 
 };
 
-# Function which saves geli keys and sets up loading of them at boot
+# Function which saves geli keys and sets up loading of them at boot.
+# Only called when key files exist in GELIKEYDIR (i.e. key file mode).
+# For passphrase mode no key files are created; the loader prompts for
+# the passphrase via geom_eli_passphrase_prompt (set in run_final_cleanup).
 setup_geli_loading()
 {
 
@@ -280,15 +291,15 @@ setup_geli_loading()
      PARTDEV="`echo ${PART} | sed 's|-|/|g'`"
      PARTNAME="`echo ${PART} | sed 's|-dev-||g'`"
 
-     rc_halt "geli configure -b ${PARTDEV}"
-
-     # If no passphrase, setup key files
+     # Key file mode: write loader.conf entries so the boot loader can
+     # read the key from /boot/keys/ and attach the GELI provider before
+     # importing the ZFS pool. Skip if a passphrase was used instead.
      if [ ! -e "${PARTDIR}-enc/${PART}-encpass" ] ; then
        echo "geli_${PARTNAME}_keyfile0_load=\"YES\"" >> ${FSMNT}/boot/loader.conf
        echo "geli_${PARTNAME}_keyfile0_type=\"${PARTNAME}:geli_keyfile0\"" >> ${FSMNT}/boot/loader.conf
        echo "geli_${PARTNAME}_keyfile0_name=\"/boot/keys/${PARTNAME}.key\"" >> ${FSMNT}/boot/loader.conf
 
-       # Copy the key to the disk
+       # Copy the key to the installed system
        rc_halt "cp ${GELIKEYDIR}/${KEYFILE} ${FSMNT}/boot/keys/${PARTNAME}.key"
      fi
 
@@ -404,12 +415,17 @@ run_final_cleanup()
     setup_geli_loading
   fi
 
-  # Make sure we have geom_eli set to load at boot
-  cat ${FSMNT}/boot/loader.conf 2>/dev/null | grep -q 'geom_eli_load="YES"' 2>/dev/null
-  if [ $? -ne 0 ]; then
-    echo 'crypto_load="YES"' >>${FSMNT}/boot/loader.conf
-    echo 'aesni_load="YES"' >>${FSMNT}/boot/loader.conf
-    echo 'geom_eli_load="YES"' >>${FSMNT}/boot/loader.conf
+  # Only add GELI loader entries when encryption is actually in use.
+  # The -bg flag on geli init already causes the loader to prompt for
+  # the passphrase during early boot, so geom_eli_passphrase_prompt
+  # is not needed and would cause a duplicate prompt.
+  grep -rq '#ON#' ${PARTDIR}/* 2>/dev/null
+  if [ $? -eq 0 ]; then
+    cat ${FSMNT}/boot/loader.conf 2>/dev/null | grep -q 'geom_eli_load="YES"' 2>/dev/null
+    if [ $? -ne 0 ]; then
+      echo 'aesni_load="YES"' >>${FSMNT}/boot/loader.conf
+      echo 'geom_eli_load="YES"' >>${FSMNT}/boot/loader.conf
+    fi
   fi
 
   # Set a hostname on the install system

--- a/backend/functions-disk.sh
+++ b/backend/functions-disk.sh
@@ -411,7 +411,16 @@ stop_all_geli()
     if [ $? -eq 0 ]
     then
       echo_log "Detaching GELI on ${i}"
-      rc_halt "geli detach ${i}"
+      rc_nohalt "geli detach ${i}"
+    fi
+  done
+
+  # Clear GELI metadata from all partitions on this disk
+  for i in `ls ${_geld}*`
+  do
+    echo $i | grep -q '.eli' 2>/dev/null
+    if [ $? -ne 0 ] ; then
+      rc_nohalt "geli clear ${i}"
     fi
   done
 

--- a/backend/functions-disk.sh
+++ b/backend/functions-disk.sh
@@ -416,12 +416,9 @@ stop_all_geli()
   done
 
   # Clear GELI metadata from all partitions on this disk
-  for i in `ls ${_geld}*`
-  do
-    echo $i | grep -q '.eli' 2>/dev/null
-    if [ $? -ne 0 ] ; then
-      rc_nohalt "geli clear ${i}"
-    fi
+  for i in ${_geld}*; do
+    [ -e "$i" ] || continue
+    echo "$i" | grep -q '.eli' 2>/dev/null || rc_nohalt "geli clear ${i}"
   done
 
 };

--- a/backend/functions-extractimage.sh
+++ b/backend/functions-extractimage.sh
@@ -685,7 +685,7 @@ init_extraction()
       start_extract_uzip_tar
       ;;
     livezfs)
-      cpdup -i0 -s0 -vvv -X zpool.cache / ${FSMNT}
+      rc_halt_echo "cpdup -i0 -s0 -vvv -X zpool.cache / ${FSMNT}"
       ;;
     *) exit_err "ERROR: Unknown install medium" ;;
   esac

--- a/backend/functions-newfs.sh
+++ b/backend/functions-newfs.sh
@@ -145,7 +145,7 @@ setup_filesystems()
     fi
 
     # Setup encryption if necessary
-    if [ "${PARTENC}" = "ON" -a "${PARTFS}" != "SWAP" ]
+    if [ "${PARTENC}" = "ON" ] && [ "${PARTFS}" != "SWAP" ]
     then
       echo_log "Creating geli provider for ${PARTDEV}"
 
@@ -174,7 +174,7 @@ setup_filesystems()
       fi
 
       EXT=".eli"
-    elif [ "${PARTENC}" = "ON" -a "${PARTFS}" = "SWAP" ]
+    elif [ "${PARTENC}" = "ON" ] && [ "${PARTFS}" = "SWAP" ]
     then
       # Swap encryption uses one-time random keys managed by the kernel
       # at boot via the .eli suffix in fstab. No geli init is needed;
@@ -187,11 +187,11 @@ setup_filesystems()
 
     # If we are doing mirrored ZFS disks, initialise GELI on each mirror member
     # using the same passphrase so all members can be unlocked at boot.
-    if [ -n "$GELI_CLONE_ZFS_DISKS" -a "$GELI_CLONE_ZFS_DEV" = "$PARTDEV" ] ; then
+    if [ -n "$GELI_CLONE_ZFS_DISKS" ] && [ "$GELI_CLONE_ZFS_DEV" = "$PARTDEV" ] ; then
        for gC in $GELI_CLONE_ZFS_DISKS
        do
          echo_log "Setting up GELI on mirrored disks: ${gC}"
-         rc_halt "geli init -b -e AES-XTS -l 256 -s 4096 -J ${PARTDIR}-enc/${PART}-encpass ${gC}"
+         rc_halt "geli init -bg -e AES-XTS -l 256 -s 4096 -J ${PARTDIR}-enc/${PART}-encpass ${gC}"
          rc_halt "geli attach -j ${PARTDIR}-enc/${PART}-encpass ${gC}"
        done
     fi

--- a/backend/functions-newfs.sh
+++ b/backend/functions-newfs.sh
@@ -83,7 +83,7 @@ setup_zfs_filesystem()
 
   if [ -n "${ZFSASHIFT}" ] ; then
     # Set specifed ashift size
-    sysctl vfs.zfs.min_auto_ashift=${ZFSASHIFT}
+    sysctl vfs.zfs.vdev.min_auto_ashift=${ZFSASHIFT}
   fi
 
   # Verify this pool isn't already in use
@@ -149,32 +149,49 @@ setup_filesystems()
     then
       echo_log "Creating geli provider for ${PARTDEV}"
 
-      rc_halt "kldstat -v |grep -q g_eli || kldload geom_eli"
-      if [ -e "${PARTDIR}-enc/${PART}-encpass" ] ; then
-        # Using a passphrase
-        rc_halt "geli init -g -b -J ${PARTDIR}-enc/${PART}-encpass ${PARTDEV}"
-        rc_halt "geli attach -j ${PARTDIR}-enc/${PART}-encpass ${PARTDEV}"
-        touch ${TMPDIR}/.grub-install-geli
-      else
-        # No Encryption password, use key file
-        rc_halt "dd if=/dev/random of=${GELIKEYDIR}/${PART}.key bs=64 count=1"
-        rc_halt "geli init -g -b -s 4096 -P -K ${GELIKEYDIR}/${PART}.key ${PARTDEV}"
-        rc_halt "geli attach -p -k ${GELIKEYDIR}/${PART}.key ${PARTDEV}"
+      # Load geom_eli and AES-NI acceleration modules
+      rc_halt "kldstat -v | grep -q g_eli || kldload geom_eli"
+      kldload aesni 2>/dev/null; true
 
+      # Clear any stale GELI metadata from a previous install
+      rc_nohalt "geli clear ${PARTDEV}"
+
+      if [ -e "${PARTDIR}-enc/${PART}-encpass" ] ; then
+        # Passphrase mode: -b flags this provider for boot-time passphrase
+        # prompt via FreeBSD's loader. -g (geliboot) tells the loader to
+        # attach this GELI provider early in boot before importing ZFS pools.
+        # AES-XTS with a 256-bit key and 4096-byte sector size matches the
+        # FreeBSD installer defaults (same as bsdinstall).
+        rc_halt "geli init -bg -e AES-XTS -l 256 -s 4096 -J ${PARTDIR}-enc/${PART}-encpass ${PARTDEV}"
+        rc_halt "geli attach -j ${PARTDIR}-enc/${PART}-encpass ${PARTDEV}"
+      else
+        # Key file mode: generate a random key stored in GELIKEYDIR and
+        # copied to /boot/keys/ on the installed system by setup_geli_loading().
+        # The -P flag disables passphrase so only the key file is required.
+        rc_halt "dd if=/dev/random of=${GELIKEYDIR}/${PART}.key bs=4096 count=1"
+        rc_halt "geli init -b -e AES-XTS -l 256 -s 4096 -P -K ${GELIKEYDIR}/${PART}.key ${PARTDEV}"
+        rc_halt "geli attach -p -k ${GELIKEYDIR}/${PART}.key ${PARTDEV}"
       fi
 
       EXT=".eli"
+    elif [ "${PARTENC}" = "ON" -a "${PARTFS}" = "SWAP" ]
+    then
+      # Swap encryption uses one-time random keys managed by the kernel
+      # at boot via the .eli suffix in fstab. No geli init is needed;
+      # just skip the EXT so glabel operates on the raw device.
+      EXT=""
     else
       # No Encryption
       EXT=""
     fi
 
-    # If we are doing mirrored ZFS disks
+    # If we are doing mirrored ZFS disks, initialise GELI on each mirror member
+    # using the same passphrase so all members can be unlocked at boot.
     if [ -n "$GELI_CLONE_ZFS_DISKS" -a "$GELI_CLONE_ZFS_DEV" = "$PARTDEV" ] ; then
        for gC in $GELI_CLONE_ZFS_DISKS
        do
          echo_log "Setting up GELI on mirrored disks: ${gC}"
-         rc_halt "geli init -g -b -J ${PARTDIR}-enc/${PART}-encpass ${gC}"
+         rc_halt "geli init -b -e AES-XTS -l 256 -s 4096 -J ${PARTDIR}-enc/${PART}-encpass ${gC}"
          rc_halt "geli attach -j ${PARTDIR}-enc/${PART}-encpass ${gC}"
        done
     fi

--- a/examples/README
+++ b/examples/README
@@ -193,7 +193,9 @@ on the target partition
 # disk0-part=UFS.eli 500 /usr
 # encpass=mypass
 # disk0-part=UFS+J 500 /tmp
-# disk0-part=ZFS 0 /data,/storage (mirror: ad1)
+# disk0-part=ZFS.eli 0 /data,/storage (mirror: ad1)
+# encpass=mypass
+# disk0-part=SWAP.eli 2000 none
 # commitDiskLabel
 
 The above values instructs pc-sysinstall which partitions / mounts
@@ -215,9 +217,20 @@ Adding the ".eli" extension to any of the above file systems
 will enable disk encryption via geli
 (UFS.eli, UFS+S.eli, UFS+SUJ.eli, UFS+J.eli, ZFS.eli, SWAP.eli)
 
-If you with to use a passphrase with this encrypted partition, on the next line
-the flag "encpass=" should be entered:
+GELI providers are initialised with AES-XTS, a 256-bit key, and
+4096-byte sectors.
+
+If you wish to use a passphrase with an encrypted partition, place
+"encpass=" on the line immediately after EACH .eli partition line:
 encpass=mypass
+
+encpass= must follow each .eli line individually. If it is omitted
+for a partition, a random key file is generated and copied to
+/boot/keys/ on the installed system; no passphrase is needed at boot.
+
+The following entries are written to /boot/loader.conf automatically:
+  aesni_load="YES"
+  geom_eli_load="YES"
 
 All sizes are expressed in MegaBytes
 Specifying a size 0 instructs pc-sysinstall to use the rest of the

--- a/examples/pcinstall.cfg.geli
+++ b/examples/pcinstall.cfg.geli
@@ -26,10 +26,9 @@ commitDiskPart
 # All sizes are expressed in MB
 # Avail FS Types, UFS, UFS+S, UFS+J, ZFS, SWAP
 # UFS.eli, UFS+S.eli, UFS+J.eli, ZFS.eli, SWAP.eli
-disk0-part=UFS 500 /boot
-disk0-part=UFS.eli 500 /
-disk0-part=UFS.eli 500 /usr
+disk0-part=ZFS.eli 0 /,/home(mountpoint=/home),/tmp(mountpoint=/tmp|exec=on|setuid=off),/usr(mountpoint=/usr|canmount=off),/usr/ports(setuid=off),/usr/src,/var(mountpoint=/var|canmount=off),/var/audit(exec=off|setuid=off),/var/crash(exec=off|setuid=off),/var/log(exec=off|setuid=off),/var/mail(atime=on),/var/tmp(setuid=off)
 encpass=mypass
+disk0-part=SWAP.eli 0 none
 commitDiskLabel
 
 # Optional Components


### PR DESCRIPTION
- Fix GELI initialization parameters: Use explicit AES-XTS cipher, 256-bit key length, and 4096-byte sector size (matching FreeBSD/bsdinstall defaults) instead of relying on implicit defaults
- Fix encrypted swap handling: Write .eli suffix in fstab for encrypted swap partitions so the kernel creates a one-time GELI provider with a random key at boot, matching standard FreeBSD behavior
- Fix ZFS ashift sysctl: Correct vfs.zfs.min_auto_ashift to vfs.zfs.vdev.min_auto_ashift
- Fix GELI cleanup: Clear stale GELI metadata before geli init to prevent failures on reinstall, and use rc_nohalt for detach/clear to avoid aborting on already-detached providers
- Fix loader.conf entries: Only write geom_eli_load and aesni_load when encryption is actually in use; remove redundant crypto_load entry
- Load aesni module during GELI setup for hardware-accelerated encryption
- Increase key file size from 64 bytes to 4096 bytes for stronger key-file-only encryption
- Fix livezfs extraction: Wrap cpdup call with rc_halt_echo for proper error handling
- Remove -g (geliboot) flag from key-file mode where it is unnecessary — only passphrase mode needs geliboot for the loader prompt
- Update examples and documentation to reflect ZFS+GELI layout with encrypted swap

## Summary by Sourcery

Improve and harden GELI disk encryption handling across installation, cleanup, and boot, aligning behavior with standard FreeBSD defaults.

Bug Fixes:
- Correct fstab entries for encrypted swap to use .eli devices so the kernel creates one-time encrypted swap at boot.
- Fix ZFS ashift tuning by using the correct vfs.zfs.vdev.min_auto_ashift sysctl.
- Prevent reinstall failures by clearing stale GELI metadata during cleanup and avoiding hard failures when detaching already-detached providers.
- Ensure live ZFS installations properly report errors by wrapping cpdup in rc_halt_echo.
- Only configure GELI-related loader.conf entries when encryption is enabled, avoiding unnecessary or redundant module loads.

Enhancements:
- Standardize GELI initialization to explicit AES-XTS with 256-bit keys and 4096-byte sectors to match FreeBSD installer defaults.
- Load AES-NI during GELI setup to enable hardware-accelerated encryption.
- Increase GELI key file size to 4096 bytes for stronger key-file-only encryption.
- Clarify and tighten key-file vs passphrase handling, including loader.conf configuration and mirrored ZFS GELI setup.